### PR TITLE
Update perp_bitget.py

### DIFF
--- a/utilities/perp_bitget.py
+++ b/utilities/perp_bitget.py
@@ -205,7 +205,7 @@ class PerpBitget():
                 })
             truePositions = []
             for position in positions:
-                if float(position['contracts']) > 0 and (symbol is None or position['symbol'] == symbol):
+                if position['contracts'] is not None and float(position['contracts']) > 0 and (symbol is None or position['symbol'] == symbol):
                     truePositions.append(position)
             return truePositions
         except BaseException as err:


### PR DESCRIPTION
Corrigé le bug TypeError dans get_open_position en ajoutant une vérification de None pour position['contracts'], évitant ainsi les erreurs de conversion en float sur des valeurs non définies.